### PR TITLE
Update on TSConfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2018",
     "module": "commonjs",
+    "moduleResolution": "node",
     "outDir": "./dist",
     "typeRoots": [
       "node_modules/@types"
@@ -20,7 +21,9 @@
     "strict": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
To fix #7

- To use `--esModuleInterop` plus `--allowSyntheticDefaultImport`. See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html
- To use `"moduleResolution": "node"`